### PR TITLE
update rust version from 1.32.0 to 1.39.0

### DIFF
--- a/docs/getting-started/local-setup.rst
+++ b/docs/getting-started/local-setup.rst
@@ -19,7 +19,7 @@ and using Homebrew on macOS.
 
     - You will probably want to add ``~/.cargo/bin`` to your system's ``PATH``
 
-- Rust v1.32.0 (``rustup default 1.32.0``)
+- Rust v1.39.0 (``rustup default 1.39.0``)
 - Clippy (``rustup component add clippy``)
 - Rustfmt (``rustup component add rustfmt``)
 - gcc


### PR DESCRIPTION
Install instructions call for rust 1.32.0. Later in the process, rust is upgraded to 1.39.0. This change installs rust 1.39.0 from the start, avoiding an unnecessary upgrade of rust.